### PR TITLE
Adding tests for KERI and automating them in build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build on every push
+name: Build and Test on every push
 
 on:
   push:
@@ -8,10 +8,9 @@ on:
       - '**'
       - '!main'
 
-
 jobs:
   build:
-    name: "Build"
+    name: "Build and Test"
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
@@ -44,3 +43,9 @@ jobs:
         uses: eskatos/gradle-command-action@v1.3.3
         with:
           arguments: build --no-daemon
+
+      # Add the test step below
+      - name: Running gradle test
+        uses: eskatos/gradle-command-action@v1.3.3
+        with:
+          arguments: test --no-daemon

--- a/src/test/kotlin/id/walt/service/TestKeriUtility.kt
+++ b/src/test/kotlin/id/walt/service/TestKeriUtility.kt
@@ -1,0 +1,23 @@
+package id.walt.service
+
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TestKeriUtility {
+    @Test
+    fun testKliVersionCommand() {
+        val command = "kli"
+        val exitCode = runShellCommand(command)
+
+        assertEquals(0, exitCode, "Command '$command' should exit with code 0")
+    }
+
+    private fun runShellCommand(command: String): Int {
+        val processBuilder = ProcessBuilder("/bin/bash", "-c", command)
+        val process = processBuilder.start()
+
+        // Wait for the command to complete
+        return process.waitFor()
+    }
+}


### PR DESCRIPTION
This PR adds the following benefits:
* Testing whether `kli` CLI command is installed in our environment (Test if this PR #31 has no issues, otherwise a hotfix is needed)
* Automates testing on every build